### PR TITLE
Admin can now delete published recipes and set recipe's attribute pub…

### DIFF
--- a/client/src/components/recipes/RecipesList.svelte
+++ b/client/src/components/recipes/RecipesList.svelte
@@ -1,6 +1,7 @@
 <script>
   import Card from '@/components/common/Card.svelte';
   import { createEventDispatcher } from 'svelte';
+  import { recipeApi } from '@/api';
 
   export let category = null;
   export let published = null;
@@ -21,6 +22,19 @@
     const isPublishedNotSelected = published === 0;
     return doPublishedMatch || isPublishedNotSelected;
   };
+
+  const remove = async id => {
+    if (!id) return alert('Delete failed, try again');
+    await recipeApi.remove(id);
+    dispatch('refetch');
+  };
+
+  const updateIsPublished = async (id, isPublished) => {
+    await recipeApi.updateIsPublished(id, isPublished);
+    const recipe = recipes.find(recipe => recipe.id === id);
+    recipe.isPublished = !recipe.isPublished;
+    recipes = [...recipes];
+  };
 </script>
 
 <section>
@@ -33,8 +47,8 @@
         time={preparationTime}
         {shouldDisplayBonusActions}
         {isPublished}
-        on:remove={() => dispatch('remove', { id })}
-        on:update={() => dispatch('update', { id, isPublished })}
+        on:remove={remove(id)}
+        on:update={updateIsPublished(id, isPublished)}
       />
     {/if}
   {/each}

--- a/client/src/components/recipes/RecipesPublished.svelte
+++ b/client/src/components/recipes/RecipesPublished.svelte
@@ -14,28 +14,19 @@
     category = value;
   }
 
-  onMount(async () => {
+  const fetchRecipesAndCategories = async () => {
     recipes = await recipeApi.fetchPublished();
     categories = await categoryApi.fetchAll();
+  };
+
+  onMount(async () => {
+    await fetchRecipesAndCategories();
   });
-
-  const remove = async ({ detail: { id } }) => {
-    if (!id) return alert('Delete failed, try again');
-    await recipeApi.remove(id);
-    recipes = await recipeApi.fetchPublished();
-  };
-
-  const updateIsPublished = async ({ detail: { id, isPublished } }) => {
-    await recipeApi.updateIsPublished(id, isPublished);
-    const recipe = recipes.find(recipe => recipe.id === id);
-    recipe.isPublished = !recipe.isPublished;
-    recipes = await recipeApi.fetchPublished();
-  };
 </script>
 
 <main>
   <Filter {categories} on:update={updateCategory} />
-  <Recipes {recipes} {category} {shouldDisplayBonusActions} on:remove={remove} on:update={updateIsPublished} />
+  <Recipes {recipes} {category} {shouldDisplayBonusActions} on:refetch={() => fetchRecipesAndCategories()} />
 </main>
 
 <style>

--- a/client/src/components/recipes/RecipesPublished.svelte
+++ b/client/src/components/recipes/RecipesPublished.svelte
@@ -3,12 +3,12 @@
   import Filter from '@/components/common/Filter.svelte';
   import Recipes from './RecipesList.svelte';
   import { recipeApi, categoryApi } from '@/api';
+  import { isAdmin } from '@/stores/auth';
 
   let category = 0;
   let recipes = [];
   let categories;
-  let userRole = JSON.parse(localStorage.getItem('user')).role.name;
-  const shouldDisplayBonusActions = userRole === 'admin' ? true : false;
+  const shouldDisplayBonusActions = isAdmin();
 
   function updateCategory({ detail: { value } }) {
     category = value;

--- a/client/src/components/recipes/RecipesPublished.svelte
+++ b/client/src/components/recipes/RecipesPublished.svelte
@@ -7,7 +7,8 @@
   let category = 0;
   let recipes = [];
   let categories;
-  const shouldDisplayBonusActions = false;
+  let userRole = JSON.parse(localStorage.getItem('user')).role.name;
+  const shouldDisplayBonusActions = userRole === 'admin' ? true : false;
 
   function updateCategory({ detail: { value } }) {
     category = value;
@@ -17,11 +18,24 @@
     recipes = await recipeApi.fetchPublished();
     categories = await categoryApi.fetchAll();
   });
+
+  const remove = async ({ detail: { id } }) => {
+    if (!id) return alert('Delete failed, try again');
+    await recipeApi.remove(id);
+    recipes = await recipeApi.fetchPublished();
+  };
+
+  const updateIsPublished = async ({ detail: { id, isPublished } }) => {
+    await recipeApi.updateIsPublished(id, isPublished);
+    const recipe = recipes.find(recipe => recipe.id === id);
+    recipe.isPublished = !recipe.isPublished;
+    recipes = await recipeApi.fetchPublished();
+  };
 </script>
 
 <main>
   <Filter {categories} on:update={updateCategory} />
-  <Recipes {recipes} {category} {shouldDisplayBonusActions} />
+  <Recipes {recipes} {category} {shouldDisplayBonusActions} on:remove={remove} on:update={updateIsPublished} />
 </main>
 
 <style>

--- a/client/src/components/recipes/RecipesUser.svelte
+++ b/client/src/components/recipes/RecipesUser.svelte
@@ -18,27 +18,18 @@
     published = !(value - 1);
   }
 
+  const fetchRecipes = async () => {
+    recipes = await recipeApi.fetchByUser();
+  };
+
   onMount(async () => {
-    recipes = await recipeApi.fetchByUser();
+    await fetchRecipes();
   });
-
-  const remove = async ({ detail: { id } }) => {
-    if (!id) return alert('Delete failed, try again');
-    await recipeApi.remove(id);
-    recipes = await recipeApi.fetchByUser();
-  };
-
-  const updateIsPublished = async ({ detail: { id, isPublished } }) => {
-    await recipeApi.updateIsPublished(id, isPublished);
-    const recipe = recipes.find(recipe => recipe.id === id);
-    recipe.isPublished = !recipe.isPublished;
-    recipes = [...recipes];
-  };
 </script>
 
 <main>
   <Filter {categories} on:update={updateCategory} />
-  <Recipes {recipes} {published} {shouldDisplayBonusActions} on:remove={remove} on:update={updateIsPublished} />
+  <Recipes {recipes} {published} {shouldDisplayBonusActions} on:refetch={() => fetchRecipes()} />
 </main>
 
 <style>


### PR DESCRIPTION
## SUMMARY

### Type of change
- Feature

### Description
Admin is now able to delete published recipes. Admin can set attribute "isPublished" to false on published recipes.

#### Why is it needed?
Admin must control all published recipes.

#### What does it do?
As admin:
  - delete published recipe
  - set "isPublished" to false on published recipe